### PR TITLE
format so you can copy/paste as is

### DIFF
--- a/docs/Walkthrough_secretContract.md
+++ b/docs/Walkthrough_secretContract.md
@@ -10,24 +10,26 @@ Create a brand new Rust library containing our secret contract logic with the fo
 
 Copy and paste the contents of the `secret_contracts/Cargo.toml.template`file into the `Cargo.toml` file inside the library of `secret_contracts/millionaires_problem` that was just created. 
 
-Under `[dependencies]` add this line: `serde = “1.0.84”`.
+Under `[dependencies]` add this line: `serde = "1.0.84"`.
 
 The full `Cargo.toml` file should now read:
 
 	
 	[package]
-		name = "contract"  
-       version = "0.1.0"  
-       [dependencies]  
-       eng-wasm = { git = "https://github.com/enigmampc/enigma-core.git", branch = "develop" }  
-       eng-wasm-derive = { git = "https://github.com/enigmampc/enigma-core.git", branch = "develop" }  
-       serde = "1.0.84"  
-       [lib]  
-       crate-type = ["cdylib"]  
-       [profile.release]  
-       panic = "abort"  
-       lto = true  
-       opt-level = "z"
+	name = "contract"  
+	version = "0.1.0"  
+
+	[lib]  
+	crate-type = ["cdylib"] 
+	
+	[dependencies]  
+	eng-wasm = { git = "https://github.com/enigmampc/enigma-core.git", branch = "develop" }  
+	eng-wasm-derive = { git = "https://github.com/enigmampc/enigma-core.git", branch = "develop" }serde = "1.0.84"
+
+	[profile.release]  
+	panic = "abort"  
+	lto = true  
+	opt-level = "z"
     
 
 
@@ -37,23 +39,21 @@ Open the `lib.rs` file located at `secret_contracts/millionaires_problem/src/lib
 
 Delete existing file contents.  Add the following code.
 
-    `
     // Built-In Attributes
     #![no_std]
-    `
-    All of our secret contracts exactly like this, because the SGX environment does not support all the features of Rust's standard library.  [This attribute](https://medium.com/r/?url=http%3A%2F%2Frust%20import)  removes the standard library from our program’s prelude accordingly.
 
-	Now add:
-	```
+All of our secret contracts start exactly like this, because the SGX environment does not support all the features of Rust's standard library.  [This attribute](https://medium.com/r/?url=http%3A%2F%2Frust%20import)  removes the standard library from our program’s prelude accordingly.
+
+Now add:
+
 	// Imports
 	extern crate eng_wasm;
 	extern crate eng_wasm_derive;
 	extern crate serde;
-	``
+	
 	use eng_wasm::*;
 	use eng_wasm_derive::pub_interface;
 	use serde::{Serialize, Deserialize};
-	```
 	
 This brings the following packages into scope:
 
@@ -63,22 +63,20 @@ This brings the following packages into scope:
 -   `serde::{Serialize, Deserialize}` — Allows us to serialize and deserialize custom struct types.
 
 Next add:
-	`
+
 	// Encrypted state keys
 	static MILLIONAIRES: &str = "millionaires";
-	`
+	
 Secret contracts can maintain encrypted state. Our contract needs to maintain a list of millionaires in state, which must have an entry `<key, value>` pair that looks something like this: `<"millionaires", <vector of Millionaire structs>>`. As shown, `"millionaires"` is the key into this encrypted state maintaining the list of millionaires.
 	
 Below the state keys, add:
 
-	~~~
 	// Structs
 	#[derive(Serialize, Deserialize)]
 	pub struct Millionaire {
 	address: H160,
 	net_worth: U256,
 	}
-	~~~
 
 A millionaire’s metadata consists the following attributes: 
 	1. ETH `address` 
@@ -88,21 +86,20 @@ Note the variable types.  `address` is of type `H160`, which corresponds to a 16
 	*(For those of you with Solidity backgrounds, you can think of these as `address`and `uint256` types, respectively.)*
 
 Now add:
-	```
+
 	// Public struct Contract which will consist of private and public-	facing secret contract functions
 	pub struct Contract;
-	```
-	This initializes a public struct called `Contract` which can consist of both private and public-facing functions to be defined later.
+
+This initializes a public struct called `Contract` which can consist of both private and public-facing functions to be defined later.
 	
 Add:
-	```
+
 	// Private functions accessible only by the secret contract
 	impl Contract {
 		fn get_millionaires() -> Vec<Millionaire> {
 			read_state!(MILLIONAIRES).unwrap_or_default()
 		}
 	}
-	```
 
 This code implements the private methods for the secret contract. `get_millionaires()` returns `Vec<Millionaire>`, a vector of Millionaire structs stored in state. 
 *Note how we read from secret contract state with the macro* `read_state!(<key>)`. 
@@ -111,14 +108,13 @@ The  `unwrap_or_default()`  [method](https://medium.com/r/?url=https://doc.rust-
 	
 Next, add:
 
-	`
 	// Public trait defining public-facing secret contract functions
 	#[pub_interface]
 	pub trait ContractInterface{
 		fn add_millionaire(address: H160, net_worth: U256);
 		fn compute_richest() -> H160;
 	}
-	`
+	
 This section declares the public-facing secret contract signatures by creating a public  `trait`  with the  `#[pub_interface]`  macro. 
 
 In this case, there is now a  `trait`  called  `ContractInterface`  and two method definitions:
@@ -129,7 +125,6 @@ In this case, there is now a  `trait`  called  `ContractInterface`  and two meth
 
 Now add:
 
-	`
 	// Implementation of the public-facing secret contract functions defined in the ContractInterface
 	// trait implementation for the Contract struct above
 	impl ContractInterface for Contract {
@@ -142,7 +137,7 @@ Now add:
 	        });
 	        write_state!(MILLIONAIRES => millionaires);
 	    }
-	    ``
+
 	    #[no_mangle]
 	    fn compute_richest() -> H160 {
 	        match Self::get_millionaires().iter().max_by_key(|m| m.net_worth) {
@@ -153,7 +148,6 @@ Now add:
 	        }
 	    }
 	}
-	`
 
 This section implements the above-defined public-facing secret contract methods. Note the  `#[no_mangle]` [annotation](%28https://medium.com/r/?url=https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html?highlight=no_mangle#calling-an-unsafe-function-or-method%29) above every method definition, which turns off Rust’s automatic method/function name-changing behavior.
 


### PR DESCRIPTION
Removed quotes and formatted, tested with mkdocs and copied a contract that compiles and migrates.